### PR TITLE
chore(.gitignore): add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/node_modules/
+/coverage/
+*.d.ts
+*.js
+*.js.map


### PR DESCRIPTION
chore(.gitignore): add .gitignore file to exclude build and dependency folders

- Create .gitignore file to prevent node_modules and coverage directories from being tracked
- Exclude TypeScript definition files, JavaScript files, and source map files from version control