### PR TITLE
build(.npmignore): add `.npmignore` file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+/.github/
+/.git/
+/.gitignore
+
+/node_modules/
+/coverage/
+*.d.ts
+*.js
+*.js.map
+/tsconfig.json
+/test/


### PR DESCRIPTION
To exclude unnecessary files in production.