### PR TITLE
ci(test-and-release): add registry-url for npm publish

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -66,6 +66,7 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          registry-url: 'https://registry.npmjs.org'
 
   release:
     name: Release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "guess-number-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -18,7 +18,8 @@
         "mocha": "^11.1.0",
         "sinon": "^19.0.2",
         "typescript": "^5.8.2"
-      }
+      },
+      "version": "1.0.1"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guess-number-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A command line number guessing game with validation and error handling.",
   "keywords": [
     "cli",


### PR DESCRIPTION
- Add registry-url to npm publish step in GitHub Actions workflow and trying to fix ENEEDAUTH error

- Update patch version to v1.0.1