### PR TITLE
ci(test-and-release): add release name to GitHub Actions workflow

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -95,5 +95,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref }}
+          name: ${{ github.ref }}
           generate_release_notes: true
           files: '*.tgz'


### PR DESCRIPTION
- Add 'name' input to the action-gh-release step in the test-and-release workflow
- Ensure a clearer release name