### PR TITLE
ci(test-and-release): add permissions for publishing package

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -45,6 +45,9 @@ jobs:
   publish:
     name: Publish Package
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     needs: test
     if: startsWith(github.ref, 'refs/tags/v')
     steps:


### PR DESCRIPTION
- Add id-token and contents permissions to the Publish Package job
- Try to fix EUSAGE error