### PR TITLE
ci(test-and-release): remove repeated trigger and specify the release name

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -97,6 +97,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref }}
-          name: ${{ github.ref }}
+          name: ${{ github.ref_name }}
           generate_release_notes: true
           files: '*.tgz'

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -2,7 +2,6 @@ name: Test and Release
 
 on:
   push:
-  pull_request:
 
 jobs:
   test:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "guess-number-cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -19,7 +19,7 @@
         "sinon": "^19.0.2",
         "typescript": "^5.8.2"
       },
-      "version": "1.0.3"
+      "version": "1.0.4"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guess-number-cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A command line number guessing game with validation and error handling.",
   "keywords": [
     "cli",


### PR DESCRIPTION
* [ci: remove repeated workflow trigger](https://github.com/PuppyOne/guess-number-cli/commit/a4d3b94d1ebf4311cf728cf771f2ac8164ef2b16)

  - Remove 'pull_request' trigger from test-and-release.yml
  - Simplify workflow activation to only respond to 'push' events

  To avoid PR repeate trigger workflow

* [ci: clear release version name](https://github.com/PuppyOne/guess-number-cli/commit/a7d5dc3dc44c49c08ab1b3415f7fc7a17c8c04a2)

  - name: `github.ref` => `github.ref_name`